### PR TITLE
Modify API token handling for server side

### DIFF
--- a/src/app/api/figma/[fileId]/route.ts
+++ b/src/app/api/figma/[fileId]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { validators } from "../../../../lib/validation";
 import { security } from "../../../../lib/security";
-import { createFigmaApiClient } from "../../../../lib/api-client";
+import { createServerSideFigmaApiClient } from "../../../../lib/api-client";
 
 // Figma APIレスポンスの型定義
 interface FigmaFileResponse {
@@ -79,7 +79,7 @@ async function handleFigmaRequest(
     const sanitizedFileId = securityCheck.sanitized!;
 
     // 統合APIクライアントを使用してFigma APIを呼び出し
-    const figmaClient = createFigmaApiClient();
+    const figmaClient = createServerSideFigmaApiClient();
     const response = await figmaClient.get<FigmaFileResponse>(`/files/${sanitizedFileId}`);
 
     // レスポンスデータのサニタイゼーションと構造化


### PR DESCRIPTION
<!-- Restrict API token usage to server-side only to enhance security. -->

This change was requested to ensure API tokens are never exposed on the client-side, aligning with the repository's goal of being a secure template for future services.