### PR TITLE
Fix CodeQL database initialization error

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -5,7 +5,7 @@ disable-default-queries: false
 # 実行するクエリスイートの設定
 queries:
   # セキュリティ関連のクエリを優先
-  uses: security-and-quality
+  - uses: security-and-quality
 
 # パス設定
 paths:
@@ -34,14 +34,10 @@ paths-ignore:
   - "**/__tests__/**"
   - "**/storybook-static/**"
 
-# 追加のパック（将来の拡張用）
+# 追加のパック（安全に動作するもののみ）
 packs:
-  # Node.js セキュリティパック
+  # 標準的なJavaScriptセキュリティパック
   - codeql/javascript-queries
-  # React セキュリティパック
-  - codeql/javascript-queries:Security
-  # TypeScript セキュリティパック
-  - codeql/javascript-queries:security-extended
 
 # カスタムクエリの設定（プロジェクト固有）
 query-filters:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         # セキュリティ重視のクエリを有効化
-        queries: security-extended,security-and-quality
+        queries: security-and-quality
         # カスタムクエリの追加（将来の拡張用）
         # query-filters: |
         #   include:


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix CodeQL analysis error by removing references to non-existent `security-extended` pack and correcting configuration format.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `security-extended` CodeQL pack caused a "not a directory" error during analysis, indicating it's no longer available or referenced incorrectly. This PR removes its references from both the workflow and configuration files, and also corrects a formatting issue in the `codeql-config.yml` to ensure proper CodeQL execution.

---

[Slack Thread](https://nidomi-io.slack.com/archives/C095ETHJ29G/p1752279579947989?thread_ts=1752279579.947989&cid=C095ETHJ29G)